### PR TITLE
update Go to 1.25.9 for security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22
 
-ENV GO_VERSION=1.25.5
+ENV GO_VERSION=1.25.9
 
 ADD https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip .
 ADD https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz .

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/sil-org/app-monitoring-archiver
 
 // Ensure this tracks with Dockerfile
-go 1.25
+go 1.25.9
 
 require (
 	github.com/aws/aws-lambda-go v1.51.0


### PR DESCRIPTION
[Go 1.25.9 Release Notes](https://go.dev/doc/devel/release#go1.25.9)