### PR TITLE
update Go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22
 
-ENV GO_VERSION=1.25.9
+ENV GO_VERSION=1.26.3
 
 ADD https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip .
 ADD https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz .

--- a/cdk/go.mod
+++ b/cdk/go.mod
@@ -1,6 +1,6 @@
 module cdk
 
-go 1.25
+go 1.26.3
 
 require (
 	github.com/aws/aws-cdk-go/awscdk/v2 v2.232.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/sil-org/app-monitoring-archiver
 
 // Ensure this tracks with Dockerfile
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/aws/aws-lambda-go v1.51.0


### PR DESCRIPTION
[ITSESUP-39](https://support.gtis.sil.org/tickets/ITSESUP-39) github-youtrack-sync govulncheck alert