### PR TITLE
use vars for information that is not sensitive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
           CONTACT_GROUP_NAME: ${{ vars.CONTACT_GROUP_NAME }}
           COUNT_LIMIT: ${{ vars.COUNT_LIMIT }}
           PERIOD: ${{ vars.PERIOD }}
-          SPREADSHEET_ID: ${{ secrets.SPREADSHEET_ID }}
-          GOOGLE_AUTH_CLIENT_EMAIL: ${{ secrets.GOOGLE_AUTH_CLIENT_EMAIL }}
-          GOOGLE_AUTH_PRIVATE_KEY_ID: ${{ secrets.GOOGLE_AUTH_PRIVATE_KEY_ID }}
+          SPREADSHEET_ID: ${{ vars.SPREADSHEET_ID }}
+          GOOGLE_AUTH_CLIENT_EMAIL: ${{ vars.GOOGLE_AUTH_CLIENT_EMAIL }}
+          GOOGLE_AUTH_PRIVATE_KEY_ID: ${{ vars.GOOGLE_AUTH_PRIVATE_KEY_ID }}
           GOOGLE_AUTH_PRIVATE_KEY: ${{ secrets.GOOGLE_AUTH_PRIVATE_KEY }}
-          GOOGLE_AUTH_TOKEN_URI: ${{ secrets.GOOGLE_AUTH_TOKEN_URI }}
+          GOOGLE_AUTH_TOKEN_URI: ${{ vars.GOOGLE_AUTH_TOKEN_URI }}
           APP_ENV: "prod"
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
         run: cd cdk && cdk deploy --require-approval never


### PR DESCRIPTION
[ITSE-1166](https://support.gtis.sil.org/issue/ITSE-1166) Change dev oauth credentials for app-montoring-archiver

### Changed
- the workflow configuration to use `vars` rather than `secrets` so maintenance is easier. I used a temporary change to the workflow file to dump these values so I could inspect them and save them as environment variables.