### PR TITLE
ITSE-2221: Wire SENTRY_DSN into Lambda and flush before fatal exit

### DIFF
--- a/cdk/cdk.go
+++ b/cdk/cdk.go
@@ -38,6 +38,8 @@ func NewCdkStack(scope constructs.Construct, id string, props *CdkStackProps) aw
 	googleAuthPrivateKey := os.Getenv("GOOGLE_AUTH_PRIVATE_KEY")
 	googleAuthTokenURI := os.Getenv("GOOGLE_AUTH_TOKEN_URI")
 
+	sentryDSN := os.Getenv("SENTRY_DSN")
+
 	stack := awscdk.NewStack(scope, &id, &sprops)
 
 	logGroup := awslogs.NewLogGroup(stack, jsii.String("LambdaLogGroup"), &awslogs.LogGroupProps{
@@ -55,6 +57,7 @@ func NewCdkStack(scope constructs.Construct, id string, props *CdkStackProps) aw
 			"GOOGLE_AUTH_PRIVATE_KEY":    &googleAuthPrivateKey,
 			"GOOGLE_AUTH_TOKEN_URI":      &googleAuthTokenURI,
 			"APP_ENV":                    &envName,
+			"SENTRY_DSN":                 &sentryDSN,
 		},
 		FunctionName:  jsii.String(appName + "-" + customer + "-" + envName),
 		Handler:       jsii.String("bootstrap"),

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -39,6 +39,7 @@ func handler(config ArchiveToGoogleSheetsConfig) error {
 	nodePingToken, err := getRequiredEnv(cmd.NodePingTokenKey)
 	if err != nil {
 		sentry.CaptureException(err)
+		sentry.Flush(2 * time.Second)
 		log.Fatalln(err)
 	}
 
@@ -46,6 +47,7 @@ func handler(config ArchiveToGoogleSheetsConfig) error {
 	if err != nil {
 		err = fmt.Errorf("error converting CountLimit '%s' to integer: %w", config.CountLimit, err)
 		sentry.CaptureException(err)
+		sentry.Flush(2 * time.Second)
 		log.Fatalln(err)
 	}
 
@@ -58,6 +60,7 @@ func handler(config ArchiveToGoogleSheetsConfig) error {
 	)
 	if err != nil {
 		sentry.CaptureException(err)
+		sentry.Flush(2 * time.Second)
 		log.Fatalln(err)
 	}
 	return nil

--- a/cmd/lambda/main.go
+++ b/cmd/lambda/main.go
@@ -25,13 +25,14 @@ type ArchiveToGoogleSheetsConfig struct {
 func main() {
 	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
 		initSentry(dsn)
-		defer sentry.Flush(2 * time.Second)
 	}
 
 	lambda.Start(handler)
 }
 
 func handler(config ArchiveToGoogleSheetsConfig) error {
+	defer sentry.Flush(2 * time.Second)
+
 	if config.Period == "" {
 		config.Period = "LastMonth"
 	}
@@ -39,16 +40,14 @@ func handler(config ArchiveToGoogleSheetsConfig) error {
 	nodePingToken, err := getRequiredEnv(cmd.NodePingTokenKey)
 	if err != nil {
 		sentry.CaptureException(err)
-		sentry.Flush(2 * time.Second)
-		log.Fatalln(err)
+		return err
 	}
 
 	intCountLimit, err := strconv.Atoi(config.CountLimit)
 	if err != nil {
 		err = fmt.Errorf("error converting CountLimit '%s' to integer: %w", config.CountLimit, err)
 		sentry.CaptureException(err)
-		sentry.Flush(2 * time.Second)
-		log.Fatalln(err)
+		return err
 	}
 
 	err = googlesheets.ArchiveResultsForMonth(
@@ -60,8 +59,7 @@ func handler(config ArchiveToGoogleSheetsConfig) error {
 	)
 	if err != nil {
 		sentry.CaptureException(err)
-		sentry.Flush(2 * time.Second)
-		log.Fatalln(err)
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
[ITSE-2221](https://support.gtis.sil.org/issue/ITSE-2221) Refine app-monitoring-archiver Sentry logs
---


### Changed

- `main.go`: single defer sentry.Flush at the top of handler replaces per-exit flushes.

### Fixed
- `cdk.go`: add SENTRY_DSN to the Lambda env so Sentry initializes.
- `main.go`: error paths return `err` instead of `log.Fatalln` so the deferred `sentry.Flush` runs and delivers events before exit.

