### PR TITLE
update Go to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:22
 
-ENV GO_VERSION=1.26.4
+ENV GO_VERSION=1.26.5
 
 ADD https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip .
 ADD https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz .

--- a/cdk/go.mod
+++ b/cdk/go.mod
@@ -1,6 +1,6 @@
 module cdk
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-cdk-go/awscdk/v2 v2.232.1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/sil-org/app-monitoring-archiver
 
 // Ensure this tracks with Dockerfile
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/aws/aws-lambda-go v1.51.0


### PR DESCRIPTION
[ITSE-2913](https://support.gtis.sil.org/issue/ITSE-2913) app-monitoring-archiver govulncheck alert

---

### Security
- Update to Go 1.26.5 for [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856).